### PR TITLE
Fixing non-linux platform builds

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -15,7 +15,9 @@ jobs:
         - {go_os: linux, go_arch: mips64}
         - {go_os: linux, go_arch: arm64}
         - {go_os: darwin, go_arch: arm64}
-
+    env:
+      GOOS: "${{ matrix.go_os }}"
+      GOARCH: "${{ matrix.go_arch }}"
     steps:
 
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,9 @@ jobs:
         - {go_os: linux, go_arch: mips64}
         - {go_os: linux, go_arch: arm64}
         - {go_os: darwin, go_arch: arm64}
-
+    env:
+      GOOS: "${{ matrix.go_os }}"
+      GOARCH: "${{ matrix.go_arch }}"
     steps:
 
     - uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/zerocube/slackr
 
-go 1.15
+go 1.18


### PR DESCRIPTION
`GOOS` and `GOARCH` were not previously set - Oops.